### PR TITLE
Change adequacy statement from Definition to Lemma in adequacy.v

### DIFF
--- a/src/adequacy.v
+++ b/src/adequacy.v
@@ -43,7 +43,7 @@ Definition simpΣ : gFunctors :=
 Global Instance subG_heapGpreS {Σ} : subG simpΣ Σ → simpGpreS Σ.
 Proof. solve_inG. Qed.
 
-Definition simp_adequacy Σ `{!simpGpreS Σ}
+Lemma simp_adequacy Σ `{!simpGpreS Σ}
            (s: stuckness) (e: expr) (σ: state) (φ: val → Prop) :
   (∀ (simpGS0: simpGS Σ), ⊢ WP e @ s; ⊤ {{ v, ⌜φ v⌝ }}) →
   adequate s e σ (λ (v: val) _, φ v).


### PR DESCRIPTION
It really confused me that it was a definition and not a lemma. After a bit of thinking, I realised that they aren't that different, so I thought there might be some subtle thing going on with Coq, but apparently not, Ralf just changed it in Iris' HeapLang. So it's probably ok to change it here as well https://gitlab.mpi-sws.org/iris/iris/-/commit/ecd139336fb207a52d8b71c5597e88861b8142c5

`adequacy.v` still type checks, and so does `parallel_add.v` (the only file that uses the lemma).